### PR TITLE
fixed incorrect initialization of Net::LDAP module

### DIFF
--- a/lib/Connector/Builtin/Authentication/LDAP.pm
+++ b/lib/Connector/Builtin/Authentication/LDAP.pm
@@ -237,7 +237,7 @@ sub _new_ldap {
     $self->log()->debug('Connecting to "' . $ldapuri .'"');
     my $ldap = Net::LDAP->new(
         $ldapuri,
-        onerror => undef,
+        onerror => 'undef',
         $self->_build_new_options(),
     );
     if(defined $ldap) {

--- a/lib/Connector/Proxy/Net/LDAP.pm
+++ b/lib/Connector/Proxy/Net/LDAP.pm
@@ -183,7 +183,7 @@ sub _init_bind {
 
     my $ldap = Net::LDAP->new(
         $self->LOCATION(),
-        onerror => undef,
+        onerror => 'undef',
         $self->_build_new_options(),
     );
 


### PR DESCRIPTION
Using the undef value instead of 'undef' masks errors during LDAP bind. This was documented incorrectly in Net::LDAP 0.65 and below and has been fixed in 0.66 (this fix works with either Net::LDAP version).